### PR TITLE
Fixed civic freedom tracker

### DIFF
--- a/src/api/api.js
+++ b/src/api/api.js
@@ -976,30 +976,27 @@ const swedenCasesByRegion = async() =>{
 };
 
 const civicFreedomTracker = async() =>{
-  const res = await axios.get('https://www.icnl.org/covid19tracker/');
-  const body = await res.data;
-  const $ = cheerio.load(body);
-  
-  const promises = [];
-
-  $('div#entries div.entry').each((index, element) =>{
-    const $element = $(element);
-    const country = $element.find('div.entrypretitle').text().trim();
-    const title = $element.find('h3').text().trim();
-    const description = $element.find('p').text().trim();
-    let type = $element.find('h6 span.regulation').text().trim() || 
-               $element.find('h6 span.order').text().trim()      ||
-               $element.find('h6 span.law').text().trim();
+  const res = await axios.get('https://www.icnl.org/covid19tracker/')
+    const body = await res.data;
+    const $ = cheerio.load(body);
     
-    const date = $element.find('h6 span.date').text().trim();
-    const issue = $element.find('h6 span.issue').text().trim();
-
-    promises.push({country , title , description , type , date, issue});
-  });
-
-  const table = [{table: promises}];
-
-  return Promise.all(table);
+    const promises = [];
+  
+    $('div#entries div.entry').each((index, element) =>{
+      const $element = $(element);
+      const country = $element.find('div.entrypretitle').text().trim();
+      const title = $element.find('h3').text().trim();
+      let type = $element.find('span.order').text().trim();
+      const date = $element.find('span.date').text().trim().substr(11);
+      const issue = $element.find('span.issue').text().trim().substr(10);
+      const description = $element.find('p').text().trim().split("\n")[0];
+  
+      promises.push({country , title , description , type , date, issue});
+    });
+  
+    const table = [{table: promises}];
+  
+    return Promise.all(table);
 };
 
 const slovakiaCasesByDistrict = async() =>{


### PR DESCRIPTION
Civic freedom tracker was outputting result with empty type, date and issue field. 
Done some modification in function to solve this problem, now it is outputting correct result without empty JSON object fields.

I have created covid19 tracker and using your API but civic freedom tracker is giving empty fields. Hope you accept this changes so that other users can also use your API efficiently.

My site : [Covid19 Tracker](https://covid19-tracker-abhay.herokuapp.com/)

![Before](https://github.com/Abhaysardhara/Abhaysardhara/blob/master/Before.PNG)

![After](https://github.com/Abhaysardhara/Abhaysardhara/blob/master/After.PNG)

